### PR TITLE
Various fixes

### DIFF
--- a/main.go
+++ b/main.go
@@ -114,16 +114,12 @@ func main() {
 			select {
 			case event := <-mywatcher.Events:
 				if (event.Op&fsnotify.Write == fsnotify.Write) || (event.Op&fsnotify.Create == fsnotify.Create) || (event.Op&fsnotify.Remove == fsnotify.Remove) {
-					log.Println("modified file:", event.Name)
 					mutex.Lock()
-
-					log.Println("got lock, updating package list...")
-					log.Println("Event: ", event)
-					distroArch := destructPath(event.Name)
 					if filepath.Base(event.Name) != "Packages.gz" {
-						log.Println("distroArch: ", distroArch)
+						log.Println("Event: ", event)
+						distroArch := destructPath(event.Name)
 						if err := createPackagesGz(parsedconfig, distroArch[0], distroArch[1], distroArch[2]); err != nil {
-							log.Println("error creating package: %s", err)
+							log.Printf("error creating package: %s", err)
 						}
 					}
 					mutex.Unlock()

--- a/main.go
+++ b/main.go
@@ -202,7 +202,7 @@ func inspectPackage(filename string) (string, error) {
 			return "", fmt.Errorf("error in inspectPackage loop: %s", err)
 		}
 
-		if header.Name == "control.tar.gz" {
+		if strings.TrimRight(header.Name, "/") == "control.tar.gz" {
 			io.Copy(&controlBuf, arReader)
 			return inspectPackageControl(controlBuf)
 		}

--- a/main.go
+++ b/main.go
@@ -273,7 +273,7 @@ func createPackagesGz(config conf, distro, section, arch string) error {
 				return err
 			}
 			packBuf.WriteString(tempCtlData)
-			dir := filepath.Join("dists", distro, section, "binary-"+arch, debFile.Name())
+			dir := filepath.ToSlash(filepath.Join("dists", distro, section, "binary-"+arch, debFile.Name()))
 			fmt.Fprintf(&packBuf, "Filename: %s\n", dir)
 			fmt.Fprintf(&packBuf, "Size: %d\n", debFile.Size())
 			f, err := os.Open(debPath)

--- a/main_test.go
+++ b/main_test.go
@@ -165,7 +165,7 @@ func TestCreateDirs(t *testing.T) {
 func TestInspectPackage(t *testing.T) {
 	parsedControl, err := inspectPackage("samples/vim-tiny_7.4.052-1ubuntu3_amd64.deb")
 	if err != nil {
-		t.Error("inspectPackage() error: %s", err)
+		t.Errorf("inspectPackage() error: %s", err)
 	}
 	if parsedControl != goodOutput {
 		t.Errorf("control file does not match")
@@ -187,7 +187,7 @@ func TestInspectPackageControl(t *testing.T) {
 	io.Copy(&controlBuf, cfReader)
 	parsedControl, err := inspectPackageControl(controlBuf)
 	if err != nil {
-		t.Error("error inspecting control file: %s", err)
+		t.Errorf("error inspecting control file: %s", err)
 	}
 	if parsedControl != goodOutput {
 		t.Errorf("control file does not match")
@@ -359,7 +359,7 @@ func TestUploadHandler(t *testing.T) {
 	// POST
 	// create "all" arch as it's the default
 	if err := os.MkdirAll(config.RootRepoPath+"/dists/stable/main/binary-all", 0755); err != nil {
-		t.Error("error creating directory for POST testing: %s", err)
+		t.Errorf("error creating directory for POST testing: %s", err)
 	}
 	sampleDeb, err := os.Open("samples/vim-tiny_7.4.052-1ubuntu3_amd64.deb")
 	if err != nil {
@@ -454,7 +454,7 @@ func TestUploadHandler(t *testing.T) {
 	uploadHandle = uploadHandler(config, db)
 	// create "all" arch as it's the default
 	if err := os.MkdirAll(config.RootRepoPath+"/dists/stable/main/binary-all", 0755); err != nil {
-		t.Error("error creating directory for POST testing: %s", err)
+		t.Errorf("error creating directory for POST testing: %s", err)
 	}
 
 	sampleDeb, err = os.Open("samples/vim-tiny_7.4.052-1ubuntu3_amd64.deb")
@@ -541,7 +541,7 @@ func TestDeleteHandler(t *testing.T) {
 	// DELETE
 	// create "all" arch as it's the default
 	if err := os.MkdirAll(config.RootRepoPath+"/dists/stable/main/binary-all", 0755); err != nil {
-		t.Error("error creating directory for POST testing: %s", err)
+		t.Errorf("error creating directory for POST testing: %s", err)
 	}
 	tempDeb, err := os.Create(config.RootRepoPath + "/dists/stable/main/binary-all/myapp.deb")
 	if err != nil {
@@ -595,7 +595,7 @@ func TestDeleteHandler(t *testing.T) {
 
 	// create "all" arch as it's the default
 	if err := os.MkdirAll(config.RootRepoPath+"/dists/stable/main/binary-all", 0755); err != nil {
-		t.Error("error creating directory for POST testing: %s", err)
+		t.Errorf("error creating directory for POST testing: %s", err)
 	}
 	tempDeb, err = os.Create(config.RootRepoPath + "/dists/stable/main/binary-all/myapp.deb")
 	if err != nil {
@@ -619,7 +619,7 @@ func TestDeleteHandler(t *testing.T) {
 	}
 
 	if err := os.MkdirAll(config.RootRepoPath+"/dists/stable/main/binary-all", 0755); err != nil {
-		t.Error("error creating directory for POST testing: %s", err)
+		t.Errorf("error creating directory for POST testing: %s", err)
 	}
 	tempDeb, err = os.Create(config.RootRepoPath + "/dists/stable/main/binary-all/myapp.deb")
 	if err != nil {


### PR DESCRIPTION
I've fixed a few errors in the test file to do with string formatting.

I've re-arranged the file directory monitoring code so it prints less to the terminal - only when it detects a new package.

I've also made the `ar` archive parsing tolerant of trailing slashes in file names, like the ones fpm produces.